### PR TITLE
Echo Server

### DIFF
--- a/connection.cpp
+++ b/connection.cpp
@@ -48,30 +48,20 @@ void connection::handle_read(const boost::system::error_code& e,
 {
   if (!e)
   {
-    boost::tribool result;
-    boost::tie(result, boost::tuples::ignore) = request_parser_.parse(
-        request_, buffer_.data(), buffer_.data() + bytes_transferred);
 
-    if (result)
+    if (buffer_[0] != '\0')
     {
-      request_handler_.handle_request(request_, reply_);
-      boost::asio::async_write(socket_, reply_.to_buffers(),
-          boost::bind(&connection::handle_write, shared_from_this(),
-            boost::asio::placeholders::error));
-    }
-    else if (!result)
-    {
-      reply_ = reply::stock_reply(reply::bad_request);
+      request_handler_.handle_request(buffer_, reply_);
       boost::asio::async_write(socket_, reply_.to_buffers(),
           boost::bind(&connection::handle_write, shared_from_this(),
             boost::asio::placeholders::error));
     }
     else
     {
-      socket_.async_read_some(boost::asio::buffer(buffer_),
-          boost::bind(&connection::handle_read, shared_from_this(),
-            boost::asio::placeholders::error,
-            boost::asio::placeholders::bytes_transferred));
+      reply_ = reply::stock_reply(reply::bad_request);
+      boost::asio::async_write(socket_, reply_.to_buffers(),
+          boost::bind(&connection::handle_write, shared_from_this(),
+            boost::asio::placeholders::error));
     }
   }
   else if (e != boost::asio::error::operation_aborted)

--- a/connection.hpp
+++ b/connection.hpp
@@ -63,7 +63,7 @@ private:
   request_handler& request_handler_;
 
   /// Buffer for incoming data.
-  boost::array<char, 8192> buffer_;
+  char buffer_[8192] = {0};
 
   /// The incoming request.
   request request_;

--- a/request_handler.cpp
+++ b/request_handler.cpp
@@ -25,8 +25,9 @@ request_handler::request_handler(const std::string& doc_root)
 {
 }
 
-void request_handler::handle_request(const request& req, reply& rep)
+void request_handler::handle_request(const char buffer_[8192], reply& rep)
 {
+  /*
   // Decode url to path.
   std::string request_path;
   if (!url_decode(req.uri, request_path))
@@ -66,12 +67,15 @@ void request_handler::handle_request(const request& req, reply& rep)
     rep = reply::stock_reply(reply::not_found);
     return;
   }
+  */
+  //always extension txt
+  std::string extension = "html";
 
   // Fill out the reply to be sent to the client.
   rep.status = reply::ok;
-  char buf[512];
-  while (is.read(buf, sizeof(buf)).gcount() > 0)
-    rep.content.append(buf, is.gcount());
+  for (int i =0; buffer_[i] != '\0' || i < 8192; i++)
+    rep.content.append(1, buffer_[i]);
+
   rep.headers.resize(2);
   rep.headers[0].name = "Content-Length";
   rep.headers[0].value = boost::lexical_cast<std::string>(rep.content.size());

--- a/request_handler.hpp
+++ b/request_handler.hpp
@@ -29,7 +29,7 @@ public:
   explicit request_handler(const std::string& doc_root);
 
   /// Handle a request and produce a reply.
-  void handle_request(const request& req, reply& rep);
+  void handle_request(const char buffer_[8192], reply& rep);
 
 private:
   /// The directory containing the files to be served.


### PR DESCRIPTION
-Changed the logic of connection class
  -simple char buffer_[8192] added instead of boost::asio::buffer
  -handle_read function now simply passes its buffer to request handler.

-Changed logic of request_handler
  -handle request now takes in a char buffer.
  -instead of parsing clients request, handle_request method just reads back
   contents in the buffer.

TODO: clean up unneccesary code. Also, 4 bytes returned at end. I believe these are the '/r/n/r/n' but not sure.