### PR TITLE
Use config format of common API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GMOCK_PATH=nginx-configparser/googletest/googlemock
 GTEST_IMPORT=-I$(GTEST_PATH)/include -I./src $(GTEST_PATH)/src/gtest_main.cc
 GMOCK_IMPORT=-I$(GMOCK_PATH)/include
 TEST_FILES=test/*.cpp
-BOOST_FLAGS=-lpthread -lboost_system -L$(BOOST_PATH)
+BOOST_FLAGS=-lpthread -lboost_system
 RESULTS_TEST_DIR=results-unit-tests
 RESULTS_COVERAGE_DIR=results-coverage
 
@@ -23,8 +23,7 @@ CONNECTION_DEPENDENCIES=src/connection.cpp src/connection_manager.cpp src/reques
 all: webserver 
 
 webserver: $(SRC_FILES)
-	g++ $(CXXFLAGS) -I$(BOOST_PATH) -I. $(SRC_FILES) -o \
-	webserver $(BOOST_FLAGS)
+	g++ $(CXXFLAGS) -I. $(SRC_FILES) -o webserver $(BOOST_FLAGS)
 
 test:
 	g++ $(CXXFLAGS) $(GTEST_IMPORT) \

--- a/README.md
+++ b/README.md
@@ -2,13 +2,6 @@
 
 A full HTTP web server, from the [boost documentation](http://www.boost.org/doc/libs/1_53_0/doc/html/boost_asio/examples.html). This code is an adapted version of the [HTTP server](http://www.boost.org/doc/libs/1_62_0/doc/html/boost_asio/examples/cpp11_examples.html) example.
 
-### Getting started
-Set the `BOOST_PATH` environment variable to the location where you downloaded Boost.
-For example:
-```
-export BOOST_PATH=~/Desktop/TODO-Team-Name/boost_1_63_0
-```
-
 ### Usage
 Edit `config` to define the port on which you want the server to run. Run server using:
 ```

--- a/config
+++ b/config
@@ -1,10 +1,16 @@
-server {
-	listen 8080;
-	path /echo EchoHandler;
-	path /static1 StaticFileHandler {
-		root www;
-	}
-	path /static2 StaticFileHandler {
-		root pics;
-	}
+# This is a comment.
+
+port 8080;   # This is also a comment.
+
+path /static1 StaticHandler {
+	root www;
 }
+
+path /static2 StaticHandler {
+	root pics;
+}
+
+path /echo EchoHandler {}
+
+# Default response handler if no handlers match.
+default NotFoundHandler {}

--- a/src/request_handler_static.cpp
+++ b/src/request_handler_static.cpp
@@ -7,6 +7,7 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 //
+
 #include <iostream>
 #include "request_handler_static.hpp"
 #include <fstream>
@@ -39,12 +40,12 @@ void request_handler_static::handle_request(const request& req, reply& rep) {
   // gets the desired path
   std::string request_path = request_string.substr(0, request_string.find('/', 1));
   //first part of url is the path, as specified in config. Check map TODO:
-  if ( server_options_->static_files_map.find(request_path) == server_options_->static_files_map.end() ) {
+  if ( server_options_->static_handlers.find(request_path) == server_options_->static_handlers.end() ) {
     // not found
     std::cout << "PATH NOT FOUND; " << request_path << "\n"; //TODO: legit error handling
   } else {
     // found
-    static_file_root_ = server_options_->static_files_map.at(request_path);
+    static_file_root_ = server_options_->static_handlers.at(request_path);
   }
   //this string contains the actual path to the file.
   std::string request_file = request_string.substr(request_string.find(request_path)+request_path.length());

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -22,8 +22,8 @@ server::server(const std::string& address, const server_options* server_options_
     acceptor_(io_service_),
     connection_manager_(),
     new_connection_(),
-    request_handler_static_(server_options_),                   //Static needs server options to access map for multiple paths
-    request_handler_echo_(server_options_->echo_handler_path),  //This is assuming there will be only one echo path
+    request_handler_static_(server_options_),                     // TODO: refactor this
+    request_handler_echo_(server_options_->echo_handlers.at(0)),  // TODO: support multiple echo handlers
     server_options_(server_options_) {
   // Get the port
   std::string port = server_options_->port;

--- a/src/server_options.hpp
+++ b/src/server_options.hpp
@@ -1,18 +1,13 @@
 //
-// request.hpp
-// ~~~~~~~~~~~
-//
-// Copyright (c) 2003-2012 Christopher M. Kohlhoff (chris at kohlhoff dot com)
-//
-// Distributed under the Boost Software License, Version 1.0. (See accompanying
-// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-//
+// server_options.hpp
+// 
 
 #ifndef SERVER_OPTIONS_HPP
 #define SERVER_OPTIONS_HPP
 
 #include <string>
 #include <map>
+#include <vector>
 
 namespace http {
 namespace server {
@@ -20,10 +15,15 @@ namespace server {
 // Holds the parsed config server options
 struct server_options {
   std::string port;
-  std::string echo_handler_path;
 
-  // Key of the map is the path in url, value is the root on localhost
-  std::map<std::string, std::string> static_files_map;
+  // Vector of echo handlers (each string represents the URL path)
+  std::vector<std::string> echo_handlers;
+
+  // Map of static handlers (key is the path, value is the root from which to serve files)
+  std::map<std::string, std::string> static_handlers;
+
+  // Default response handler
+  std::string default_handler;
 };
 
 } // namespace server


### PR DESCRIPTION
Implementation of config parsing for the [common API](https://github.com/UCLA-CS130/webserver-api). I changed the `server_options` struct to support a vector of strings that specify echo handler paths, but for now the server will just take the first echo handler that's specified (we'll need to update this when we refactor all of the request handlers to support multiple echo handlers)

I also realized that as long as you installed boost correctly on your machine we don't need the extra -L and -I flags in the Makefile which rely on the path where you downloaded it. Got rid of it because it'll be easier for the team that starts making changes to our code to get set up next week.